### PR TITLE
修改 tasks.c 编译错误

### DIFF
--- a/FreeRTOS/tasks.c
+++ b/FreeRTOS/tasks.c
@@ -147,7 +147,11 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 prvInitialiseNewTask( pxTaskCode, pcName, ( uint32_t ) usStackDepth, pvParameters, uxPriority, pxCreatedTask, pxNewTCB, ( StackType_t * ) stack_start );
                 xReturn = pdPASS;
                 /* Mark as dynamic */
+#if RT_VER_NUM < 0x50000
+                ( ( struct rt_thread * ) pxNewTCB )-> type &= ~RT_Object_Class_Static;
+#else
                 ( ( struct rt_thread * ) pxNewTCB )-> parent.type &= ~RT_Object_Class_Static;
+#endif /* RT_VER_NUM < 0x50000 */
                 rt_thread_startup( ( rt_thread_t ) pxNewTCB );
             }
             else
@@ -556,7 +560,11 @@ UBaseType_t uxTaskGetNumberOfTasks( void )
 char * pcTaskGetName( TaskHandle_t xTaskToQuery )
 {
     rt_thread_t thread = ( rt_thread_t ) prvGetTCBFromHandle( xTaskToQuery );
+#if RT_VER_NUM < 0x50000
+    return &( thread->name[ 0 ] );
+#else
     return &( thread->parent.name[ 0 ] );
+#endif /* RT_VER_NUM < 0x50000 */
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS/tasks.c
+++ b/FreeRTOS/tasks.c
@@ -147,7 +147,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 prvInitialiseNewTask( pxTaskCode, pcName, ( uint32_t ) usStackDepth, pvParameters, uxPriority, pxCreatedTask, pxNewTCB, ( StackType_t * ) stack_start );
                 xReturn = pdPASS;
                 /* Mark as dynamic */
-                ( ( struct rt_thread * ) pxNewTCB )->type &= ~RT_Object_Class_Static;
+                ( ( struct rt_thread * ) pxNewTCB )-> parent.type &= ~RT_Object_Class_Static;
                 rt_thread_startup( ( rt_thread_t ) pxNewTCB );
             }
             else
@@ -556,7 +556,7 @@ UBaseType_t uxTaskGetNumberOfTasks( void )
 char * pcTaskGetName( TaskHandle_t xTaskToQuery )
 {
     rt_thread_t thread = ( rt_thread_t ) prvGetTCBFromHandle( xTaskToQuery );
-    return &( thread->name[ 0 ] );
+    return &( thread->parent.name[ 0 ] );
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
修改 `task.c` 编译错误，目前`struct rt_thread`结构体已无`type`和`name`字段，而是显式继承`struct rt_object`结构体，见 [[kernel] 将rt_thread结构体改为显式继承rt_object](https://github.com/RT-Thread/rt-thread/commit/93f3cb30e48d5de341bda09fa806120e2bc3f3ad#diff-4ed4f6ac1fb63dc69e6a720d8529b5fe0b78f43fb1ac8fe4653383026375fbab)