### PR TITLE
更改 list.c include路径问题  & 完善文档

### DIFF
--- a/FreeRTOS/list.c
+++ b/FreeRTOS/list.c
@@ -35,7 +35,7 @@
 #define MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
 #include "FreeRTOS.h"
-#include "list.h"
+#include "freertos/list.h"
 
 /* Lint e9021, e961 and e750 are suppressed as a MISRA exception justified
  * because the MPU ports require MPU_WRAPPERS_INCLUDED_FROM_API_FILE to be

--- a/readme_zh.md
+++ b/readme_zh.md
@@ -326,12 +326,18 @@ Task 1 receive data 9 from queue
 Task 1 receive data 10 from queue
 ```
 
-## 5 参考资料
+## 5 注意事项 & 补充说明
+
+1、该版本`FreeRTOS`由乐鑫公司的`esp-idf`库中迁移而来，部分函数需要根据芯片来实现，如出现编译问题可参考[bsp/ESP32_C3](https://github.com/RT-Thread/rt-thread/tree/master/bsp/ESP32_C3)和[RT-Thread-packages/esp-idf](https://github.com/RT-Thread-packages/esp-idf/tree/master/components/freertos/FreeRTOS-Kernel)。
+
+2、在`menuconfig`页面中可以开启`PKG_FREERTOS_USING_CONFIG_H`宏定义，该宏定义允许用户自定义相关`freertos`配置，具体使用案例可以参考[bsp/ESP32_C3/idf_port/include/freertos/FreeRTOSConfig.h](https://github.com/RT-Thread/rt-thread/blob/master/bsp/ESP32_C3/idf_port/include/freertos/FreeRTOSConfig.h)，注意只有部分配置宏定义可以被覆盖，详见`FreeRTOS/include/freertos/FreeRTOS.h`。
+
+## 6 参考资料
 RT-Thread文档 [https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/README](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/README)
 
 FreeRTOS文档 [https://www.freertos.org/a00106.html](https://www.freertos.org/a00106.html)
 
-## 6 维护
+## 7 维护
 
 主页：https://github.com/RT-Thread-packages/FreeRTOS-Wrapper
 


### PR DESCRIPTION
本PR主要修改一下`list.c`文件的`include`路径问题，在`https://github.com/RT-Thread-packages/esp-idf/`中同样存在一个`list.h`文件存在冲突。另外顺带完善一下文档。